### PR TITLE
Find or create a student with the cohort id

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -155,6 +155,6 @@ class Schedule < ApplicationRecord
     end
 
     def build_student(assignment)
-      Student.find_or_create_by(first_name: assignment["user"]["first_name"], last_name: assignment["user"]["last_name"]) 
+      Student.find_or_create_by(first_name: assignment["user"]["first_name"], last_name: assignment["user"]["last_name"], cohort_id: self.cohort.id)
     end
 end


### PR DESCRIPTION
Rails 5 requires the associated model to be valid. Since we were trying to create new students without a cohort id, the students were getting rolled back. 