### PR TITLE
Validates uniqueness of date per cohort

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -16,8 +16,7 @@ class Schedule < ApplicationRecord
   validates :date, presence: true
   validates :date, uniqueness: {scope: :cohort, message: 'already taken for this cohort'}
 
-  before_create :slugify
-  before_save :check_deploy
+  before_save :check_deploy, :slugify
 
   def slugify
     self.slug = self.date.strftime("%b %d, %Y").downcase.gsub(/[\s,]+/, '-')

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -14,6 +14,7 @@ class Schedule < ApplicationRecord
   accepts_nested_attributes_for :activities
   accepts_nested_attributes_for :objectives
   validates :date, presence: true
+  validates :date, uniqueness: {scope: :cohort, message: 'already taken for this cohort'}
 
   before_create :slugify
   before_save :check_deploy

--- a/app/services/new_schedule_builder.rb
+++ b/app/services/new_schedule_builder.rb
@@ -2,6 +2,8 @@ class NewScheduleBuilder
 
   def self.create_empty_schedule
     Schedule.new.tap do |schedule|
+      schedule.date = Date.tomorrow
+      
       3.times do
         schedule.objectives << Objective.new
       end

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -1,29 +1,43 @@
 require 'rails_helper'
 
 RSpec.describe Schedule, type: :model do
-  it "should have a factory" do 
+  it "should have a factory" do
     expect(FactoryGirl.build(:schedule)).to be_valid
   end
 
-  context "validations" do 
-    it "is invalid without a date" do 
+  context "validations" do
+    it "is invalid without a date" do
       expect(FactoryGirl.build(:schedule, date: nil)).to_not be_valid
+    end
+
+    it 'is invalid without a unique date per cohort' do
+      schedule = FactoryGirl.create(:schedule)
+      cohort = schedule.cohort
+      duplicate_schedule = cohort.schedules.build(date: schedule.date)
+      expect(duplicate_schedule).to_not be_valid
+    end
+
+    it 'can duplicate dates for different cohorts' do
+      schedule = FactoryGirl.create(:schedule)
+      cohort = FactoryGirl.build(:cohort)
+      duplicate_date = cohort.schedules.build(date: schedule.date )
+      expect(duplicate_date).to be_valid
     end
   end
 
-  describe "attributes" do 
+  describe "attributes" do
     let(:schedule) { FactoryGirl.build(:schedule) }
-    
-    it "has a date" do 
-      expect(schedule.date).to eq("2016-06-02 00:00:00.000000000 -0500")
-    end 
 
-    it "has notes" do 
+    it "has a date" do
+      expect(schedule.date).to eq("2016-06-02 00:00:00.000000000 -0500")
+    end
+
+    it "has notes" do
       expect(schedule.notes).to eq("Today's objective include learning all of Rails and re-building Learn.co in Elixir.")
     end
 
     it "has a slug that is a slugified version of the schedule's date" do
-      sc = Schedule.new(date: "02 Jun 2016") 
+      sc = Schedule.new(date: "02 Jun 2016")
       sc.cohort = FactoryGirl.build(:cohort)
       sc.save
       expect(sc.slug).to eq("jun-02-2016")
@@ -32,25 +46,24 @@ RSpec.describe Schedule, type: :model do
 
   context "associations" do
     let(:schedule) { FactoryGirl.build(:schedule) }
-    it "has many activities" do 
+    it "has many activities" do
       activity = FactoryGirl.build(:activity)
       schedule.activities << activity
       schedule.save
       expect(schedule.activities).to include(activity)
-    end 
+    end
 
-    it 'has many labs' do 
+    it 'has many labs' do
       lab = FactoryGirl.build(:lab)
       schedule.labs << lab
       schedule.save
       expect(schedule.labs).to include(lab)
     end
 
-    it 'belongs to a cohort' do 
+    it 'belongs to a cohort' do
       cohort = FactoryGirl.build(:cohort)
       schedule.cohort = cohort
       expect(schedule.cohort).to eq(cohort)
     end
   end
 end
-


### PR DESCRIPTION
Fixes #42 

1. This makes sure that the date for a new schedule is unique per cohort. 
2. Also makes tomorrow the value of the form field by default. 
3. Finally, updates the slug `before_save` instead of `before_create` so that if you change the date, the slug changes along with it. 

@talum @antoinfive @jjseymour 